### PR TITLE
feat: seed all at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-memos",
-  "version": "1.0.64",
+  "version": "1.0.75",
   "private": true,
   "engines": {
     "node": ">=0.10.0"

--- a/src/scripts/controller/DetailsController.js
+++ b/src/scripts/controller/DetailsController.js
@@ -16,6 +16,7 @@
  */
 
 import Controller from './Controller';
+import AppModel from '../model/AppModel';
 import MemoModel from '../model/MemoModel';
 import RouterInstance from '../libs/Router';
 import PubSubInstance from '../libs/PubSub';
@@ -492,10 +493,10 @@ export default class DetailsController extends Controller {
   }
 
   onShareButtonClick(e) {
-    MemoModel.get(this.memoId).then( (memo) => {
-      return `/share?seeds=${encodeURIComponent(memo.torrentURL)}`;
+    AppModel.get(1).then(appModel => {
+      return `/share?seeds=${encodeURIComponent(appModel.torrentURL)}`;
     }).then(uri => {
-      history.pushState({}, "Share seed", uri)
+      history.pushState({}, "Share seed", uri);
     });
   }
 

--- a/src/scripts/controller/ListController.js
+++ b/src/scripts/controller/ListController.js
@@ -16,6 +16,7 @@
  */
 
 import Controller from './Controller';
+import AppModel from '../model/AppModel';
 import MemoModel from '../model/MemoModel';
 import RouterInstance from '../libs/Router';
 import PubSubInstance from '../libs/PubSub';
@@ -29,6 +30,10 @@ export default class ListController extends Controller {
     this.memos = null;
     this.ctaView = document.querySelector('.js-cta');
     this.view = document.querySelector('.js-list-view');
+
+    AppModel.get(1).then (appModel => {
+      this.appModel = appModel;
+    });
 
     
     Promise.all([
@@ -103,22 +108,20 @@ export default class ListController extends Controller {
   }
 
   seed () {
-    this.memos.forEach((memo) => {
-      // Seed the memo.
-      TorrentInstance().then(torrentClient => {
-        torrentClient.seed(
-          memo.audio, // Audio is a blob, but that is ok.
-          {
-            name: `${memo.title}.webm`,
-            comment: memo.description || '',
-            creationDate: memo.time || Date.now()
-          },
-          torrent => {
-            console.log(torrent);
-            memo.torrentURL = torrent.magnetURI;
-            memo.put();
-          });
-      });
+    // Seed the memos.
+    TorrentInstance().then(torrentClient => {
+      torrentClient.seed(
+        this.memos.map(memo => memo.audio),
+        {
+          name: `voice-memos.webm`,
+          comment: 'all voice memos',
+          creationDate: Date.now()
+        },
+        torrent => {
+          console.log('torrent', torrent);
+          this.appModel.torrentURL = torrent.magnetURI;
+          this.appModel.put();
+        });
     });
   }
 

--- a/src/scripts/model/AppModel.js
+++ b/src/scripts/model/AppModel.js
@@ -25,6 +25,7 @@ export default class AppModel extends Model {
 
     this.firstRun = true;
     this.preferences = {};
+    this.torrentURL = data ? data.torrentURL : null;
   }
 
   static get UPDATED () {

--- a/src/scripts/model/MemoModel.js
+++ b/src/scripts/model/MemoModel.js
@@ -30,7 +30,6 @@ export default class MemoModel extends Model {
     this.volumeData = data.volumeData || null;
     this.time = data.time || Date.now();
     this.transcript = data.transcript || null;
-    this.torrentURL = data.torrentURL || null;
   }
 
   static makeURL () {


### PR DESCRIPTION
quick hack to seed all files instead in one torrent of seeding each file independently, so that
any other client can sync them at one go;
the files come across nameless (how do we encode metadata for files?
would sending a json with data work? can the metadata be encoded on the
file itself?)
I reckon that a polling mechanism (unless bittorrent can push changes?)
would allow for constant syncing of multiple sources :) (after an
initial sort of recognition by all parties, i.e., user seeds in device
a, goes to device b, syncs, seeds in device b and syncs back in device
a)
